### PR TITLE
converted $size string to int using intval

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,7 +6,8 @@ use google\appengine\api\cloud_storage\CloudStorageTools;
 syslog(LOG_WARNING, "Imported Cloud Storage Tools");
 //var_dump( $_GET);
 $imageName=$_GET["image"];
-$size=$_GET["size"];
+$size=intval($_GET["size"]);
+
 syslog(LOG_WARNING, "Object URL $object_url");
 syslog(LOG_WARNING, "Size $size");
 


### PR DESCRIPTION
This fixes the following error:

```
PHP Fatal error:  Uncaught exception 'InvalidArgumentException' with message '$options['size'] must be an integer. Actual type: string' in /base/data/home/runtimes/php/sdk/google/appengine/api/cloud_storage/CloudStorageTools.php:304
```